### PR TITLE
Fix process_client_logs.sh

### DIFF
--- a/bin/process_client_logs.sh
+++ b/bin/process_client_logs.sh
@@ -11,7 +11,7 @@ cd "$directory"/var/log || exit
 #pipe cat into an awk command that uses the following regex expression to match the required lines
 #print the capture groups in that regex expression
 #put that into a file called failed_login_data.txt
-cat ./* | awk 'match($0, /([a-zA-z]{3} [ 0-9]{2}) ([0-9]{2})[0-9:]+ [a-zA-Z]+.+ Failed password .+ ([a-zA-Z0-9 ]+) from ([0-9.]+)/, groups) {print groups[1] " " groups[2] " " groups[3] " " groups[4]}' | sed 's/"  "/ " "/' >  failed_login_data.txt
+cat ./* | awk 'match($0, /([a-zA-z]{3} [ 0-9]{2}) ([0-9]{2})[0-9:]+ [a-zA-Z]+.+ Failed password .+ ([a-zA-Z0-9 ]+) from ([0-9.]+)/, groups) {print groups[1] " " groups[2] " " groups[3] " " groups[4]}' | sed 's/  / /' >  failed_login_data.txt
 
 
 #Move the failed_login_data.txt file back into directory stored in the directory variable

--- a/bin/process_client_logs.sh
+++ b/bin/process_client_logs.sh
@@ -11,7 +11,7 @@ cd "$directory"/var/log || exit
 #pipe cat into an awk command that uses the following regex expression to match the required lines
 #print the capture groups in that regex expression
 #put that into a file called failed_login_data.txt
-cat ./* | awk 'match($0, /([a-zA-z]{3} [ 0-9]{2}) ([0-9]{2})[0-9:]+ [a-zA-Z]+.+ Failed password .+ ([a-zA-Z0-9 ]+) from ([0-9.]+)/, groups) {print groups[1] " " groups[2] " " groups[3] " " groups[4]}' >  failed_login_data.txt
+cat ./* | awk 'match($0, /([a-zA-z]{3} [ 0-9]{2}) ([0-9]{2})[0-9:]+ [a-zA-Z]+.+ Failed password .+ ([a-zA-Z0-9 ]+) from ([0-9.]+)/, groups) {print groups[1] " " groups[2] " " groups[3] " " groups[4]}' | sed 's/"  "/ " "/' >  failed_login_data.txt
 
 
 #Move the failed_login_data.txt file back into directory stored in the directory variable


### PR DESCRIPTION
This commit fixes the process_client_logs.sh script so that the double space is removed when there is a single date, such as Aug 9. So, instead of Aug   9 it is now Aug 9.

Co-authored-by: Dante Miller <mill8622@morris.umn.edu>